### PR TITLE
Updated for IS42S16320F-7TL on DE10-Lite FPGA Development Board

### DIFF
--- a/sdram.vhd.bak
+++ b/sdram.vhd.bak
@@ -47,7 +47,6 @@ entity sdram is
     --
     -- This value must be provided, as it is used to calculate the number of
     -- clock cycles required for the other timing values.
-	-- Set to 143 MHz for IS42S16320F-7TL
     CLK_FREQ : real	:= 143;
 
     -- 32-bit controller interface
@@ -63,7 +62,7 @@ entity sdram is
 
     -- The delay in clock cycles, between the start of a read command and the
     -- availability of the output data.
-    CAS_LATENCY : natural := 3; -- 2=below 133MHz, 3=above 133MHz
+    CAS_LATENCY : natural := 2; -- 2=below 133MHz, 3=above 133MHz
 
     -- The number of 16-bit words to be bursted during a read/write.
     BURST_LENGTH : natural := 2;


### PR DESCRIPTION
This version supports the Terasic DE10-Lite FPGA Development board used in the Intel FPGA Univesity Program.